### PR TITLE
Server side sync and spikes functionality.

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -203,6 +203,7 @@ RegisterNetEvent('ax:client:giveRemoveAccess',function ()
                     DrawMarker(0, (propCoords + vector3(0.0, 0.0, 1.7)), 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.5, 0.5, 0.5, 255, 255, 0, 50, true, true, 2, nil, nil, false)
                     if IsControlJustPressed(0, 38) then
                         DeleteEntity(v.prop)
+                        TriggerServerEvent('ax:server:removeProp', v.position)
                         table.remove(createdProps, k)
                         hasRemoved = true
                     end

--- a/client.lua
+++ b/client.lua
@@ -1,4 +1,8 @@
 -- SCALEFORMS
+---@diagnostic disable: undefined-global
+
+local CreateThread <const> = Citizen.CreateThread
+local Wait <const>         = Citizen.Wait
 
 local function ButtonMessage(text)
     BeginTextCommandScaleformString("STRING")
@@ -59,8 +63,32 @@ RegisterNetEvent("sync-script:polmenu:open", function(propList)
     SetNuiFocus(true, true)
 end)
 
--- MAIN THREAD
 local createdProps = {}
+
+RegisterNetEvent('ax:client:syncProps', function(props)
+    for _,v in pairs(props) do
+        local x,y,z,heading = v.position.x, v.position.y, v.position.z, v.heading
+        local propHash = GetHashKey(v.spawnCode)
+
+        if not IsObjectNearPoint(propHash, x, y, z, 0.2) then
+            local obj = CreateObject(propHash, x, y, z)
+
+            SetEntityHeading(obj, heading)
+            SetEntityCollision(obj, 1, 1)
+            FreezeEntityPosition(obj, 1)
+            SetEntityInvincible(obj, 1)
+
+            local propData = {
+                prop = obj,
+                spawnCode = v.spawnCode,
+                position = GetEntityCoords(obj),
+                heading  = GetEntityHeading(obj)
+            }
+
+            table.insert(createdProps, propData)        -- --Ax-: Needs new table bcs the entityCode can differ on client side
+        end
+    end
+end)
 
 -- RegisterNetEvent("polmenu:selProp", function()
 -- RegisterCommand("poltest", function(...)
@@ -98,7 +126,6 @@ RegisterNUICallback("polmenu:selProp", function(data, cb)
             end
 
             SetEntityCoords(propObj, ((GetEntityCoords(PlayerPedId()) + GetEntityForwardVector(PlayerPedId())) - vector3(0.0, 0.0, 1.5)))
-            -- SetEntityHeading(propObj, GetEntityHeading(PlayerPedId()))
             PlaceObjectOnGroundProperly(propObj)
 
             if IsDisabledControlJustPressed(0, config.buttons[1].key) then
@@ -112,7 +139,16 @@ RegisterNUICallback("polmenu:selProp", function(data, cb)
 
                 DeleteEntity(propObj)
 
-                table.insert(createdProps, finalObj)
+                local propData = {
+                    prop = finalObj,
+                    spawnCode = data.prop,
+                    position = GetEntityCoords(finalObj),
+                    heading  = GetEntityHeading(propObj)
+                }
+
+                table.insert(createdProps, propData)
+
+                TriggerServerEvent('ax:server:addProp', propData)
 
                 SetNotificationTextEntry("STRING")
                 AddTextComponentString(config.placeMessage)
@@ -139,27 +175,114 @@ RegisterNUICallback("polmenu:selProp", function(data, cb)
     end)
 end)
 
-CreateThread(function()
-    local ticks = 800
-    while true do 
-        local playerCoords = GetEntityCoords(PlayerPedId())
-        for k, v in pairs(createdProps) do 
-            local propCoords = GetEntityCoords(v)
-            local distance = #(playerCoords - propCoords)
 
-            if distance < 1.5 then
-                -- left corner notify 
-                SetTextComponentFormat("STRING")
-                AddTextComponentString("Press ~INPUT_PICKUP~ to remove this prop.")
-                DisplayHelpTextFromStringLabel(0, 0, 1, -1)
-                
-                ticks = 1
-                DrawMarker(0, (propCoords + vector3(0.0, 0.0, 1.7)), 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.5, 0.5, 0.5, 255, 255, 0, 50, true, true, 2, nil, nil, false)
-                if IsControlJustPressed(0, 38) then
-                    DeleteEntity(v)
-                    table.remove(createdProps, k)
-                    ticks = 800
+RegisterNetEvent('ax:client:giveRemoveAccess',function ()
+    local hasRemoved = false
+    local timeout = 0;
+    local maxTimeout = config.removeThreadTimeout * 1000
+
+    if #createdProps == 0 then
+        return
+    end
+
+    CreateThread(function()
+        local ticks = 1000
+        while not hasRemoved and timeout < maxTimeout do 
+            local playerCoords = GetEntityCoords(PlayerPedId())
+    
+            for k, v in pairs(createdProps) do 
+                local propCoords = v.position
+                local distance = #(playerCoords - propCoords)
+    
+                if distance < 1.5 then
+                    SetTextComponentFormat("STRING")
+                    AddTextComponentString("Press ~INPUT_PICKUP~ to remove this prop.")
+                    DisplayHelpTextFromStringLabel(0, 0, 1, -1)
+    
+                    ticks = 1
+                    DrawMarker(0, (propCoords + vector3(0.0, 0.0, 1.7)), 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.5, 0.5, 0.5, 255, 255, 0, 50, true, true, 2, nil, nil, false)
+                    if IsControlJustPressed(0, 38) then
+                        DeleteEntity(v.prop)
+                        table.remove(createdProps, k)
+                        hasRemoved = true
+                    end
+                else
+                    ticks = 1000
                 end
+            end
+
+            timeout = timeout + ticks
+            Wait(ticks)
+        end
+    end)
+end)
+
+local getClosestSpike <const> = function ()
+    local pos = GetEntityCoords(PlayerPedId(), true)
+    local current, dist, closestSpike
+
+    for _, v in pairs(createdProps) do
+
+        if v.spawnCode ~= config.spikesCode then
+            goto skip
+        end
+
+        local spike = v.position
+
+        if current == nil then
+            dist = #(pos - vector3(spike.x, spike.y, spike.z))
+            current = spikeID
+        elseif current then
+            if #(pos - vector3(spike.x, spike.y, spike.z)) < dist then
+                current = spikeID
+            end
+        end
+        
+        closestSpike = spike
+
+        ::skip::
+    end
+
+    return closestSpike
+end
+
+CreateThread(function ()
+    while true do
+        local ped = PlayerPedId()
+        local ticks = 1000
+        
+        while IsPedInAnyVehicle(ped, true) do
+            Wait(ticks)
+
+            local vehicle = GetVehiclePedIsIn(ped, false)
+            local closestSpike = getClosestSpike()
+
+            if closestSpike then
+                ticks = 1
+                local spikePos = closestSpike
+
+                if #(spikePos - GetEntityCoords(ped)) <= 10 then
+                    local tires = {
+                        {bone = "wheel_lf", index = 0},
+                        {bone = "wheel_rf", index = 1},
+                        {bone = "wheel_lm", index = 2},
+                        {bone = "wheel_rm", index = 3},
+                        {bone = "wheel_lr", index = 4},
+                        {bone = "wheel_rr", index = 5},
+                    }
+     
+                    for a = 1, #tires do
+                        local tirePos = GetWorldPositionOfEntityBone(vehicle, GetEntityBoneIndexByName(vehicle, tires[a].bone))
+     
+                        if #(tirePos - spikePos) < 1.8 then
+                            if not IsVehicleTyreBurst(vehicle, tires[a].index, false) then
+                                SetVehicleTyreBurst(vehicle, tires[a].index, true, 1000.0)
+                            end
+                        end
+                    end
+                end
+            else
+                ticks = 1000
             end
         end
 
@@ -167,10 +290,11 @@ CreateThread(function()
     end
 end)
 
+
 AddEventHandler("onResourceStop", function(resource)
     if resource == GetCurrentResourceName() then
         for k, v in pairs(createdProps) do 
-            DeleteEntity(v)
+            DeleteEntity(v.prop)
         end
     end
 end)

--- a/config.lua
+++ b/config.lua
@@ -1,34 +1,35 @@
 config = {}
 
-if IsDuplicityVersion() then
-    config.command = 'polmenu' -- EDIT THIS TO CHANGE THE COMMAND NAME
+config.debug = true
+config.command = 'polmenu' -- EDIT THIS TO CHANGE THE COMMAND NAME
+config.removeCommand = 'axremove'
+config.removeThreadTimeout = 30 -- in seconds
 
 -- EDIT THIS TO CHANGE THE ACCESS TO THE COMMAND
-    config.hasAccess = function(source)
-        return true  ---- note: if its true, everyone can use the command
-    end
-
-    config.noAccessMessage = "You do not have access to this command." -- EDIT THIS TO CHANGE THE NO ACCESS MESSAGE
-
--- EDIT THIS LIST TO ADD OR REMOVE PROPS
-    config.props = {
-        ["prop_roadcone01a"] = "Cone 1",
-        ["prop_barrier_work04a"] = "Barrier 1",
-        ["prop_barrier_work01a"] = "Barrier 2",
-        ["prop_barrier_work06a"] = "Barrier 3"
-    }
-else 
-    config.rotationSpeed = 2.0 -- EDIT THIS TO CHANGE THE ROTATION SPEED OF THE PROPS
-    config.disableAiming = true -- EDIT THIS TO DISABLE AIMING WHILE PLACING PROPS
-    config.placeMessage = "You have placed a prop. Go near it and press E to remove it." -- EDIT THIS TO CHANGE THE MESSAGE THAT APPEARS WHEN YOU PLACE A PROP
-
-    -- EDIT THIS TO CHANGE THE BUTTONS TEXT AND KEYBINDS
-    config.buttons = {
-        [1] = {buttonName = "Place prop", key = 24}, 
-        [2] = {buttonName = "Cancel", key = 200},
-        [3] = {buttonName = "Rotate right", key = 16},
-        [4] = {buttonName = "Rotate left", key = 17},
-    }
+config.hasAccess = function(source)
+    return true  ---- note: if its true, everyone can use the command
 end
 
-return config
+config.noAccessMessage = "You do not have access to this command." -- EDIT THIS TO CHANGE THE NO ACCESS MESSAGE
+
+config.spikesCode = "p_ld_stinger_s"
+
+-- EDIT THIS LIST TO ADD OR REMOVE PROPS
+config.props = {
+    ["prop_roadcone01a"] = "Cone 1",
+    ["prop_barrier_work04a"] = "Barrier 1",
+    ["prop_barrier_work01a"] = "Barrier 2",
+    ["prop_barrier_work06a"] = "Barrier 3",
+    ["p_ld_stinger_s"]       = "Spikes"
+}
+config.rotationSpeed = 2.0 -- EDIT THIS TO CHANGE THE ROTATION SPEED OF THE PROPS
+config.disableAiming = true -- EDIT THIS TO DISABLE AIMING WHILE PLACING PROPS
+config.placeMessage = "You have placed a prop. Go near it and press E to remove it." -- EDIT THIS TO CHANGE THE MESSAGE THAT APPEARS WHEN YOU PLACE A PROP
+
+-- EDIT THIS TO CHANGE THE BUTTONS TEXT AND KEYBINDS
+config.buttons = {
+    [1] = {buttonName = "Place prop", key = 24}, 
+    [2] = {buttonName = "Cancel", key = 200},
+    [3] = {buttonName = "Rotate right", key = 16},
+    [4] = {buttonName = "Rotate left", key = 17},
+}

--- a/config.lua
+++ b/config.lua
@@ -1,6 +1,6 @@
 config = {}
 
-config.debug = false
+config.debug = true
 config.command = 'polmenu' -- EDIT THIS TO CHANGE THE COMMAND NAME
 config.removeCommand = 'axremove'
 config.removeThreadTimeout = 30 -- in seconds
@@ -16,7 +16,7 @@ config.spikesCode = "p_ld_stinger_s"
 
 -- EDIT THIS LIST TO ADD OR REMOVE PROPS
 config.props = {
-    ["prop_roadcone01a"] = "Cone 1",
+    ["prop_roadcone01a"]     = "Cone 1",
     ["prop_barrier_work04a"] = "Barrier 1",
     ["prop_barrier_work01a"] = "Barrier 2",
     ["prop_barrier_work06a"] = "Barrier 3",
@@ -24,7 +24,7 @@ config.props = {
 }
 config.rotationSpeed = 2.0 -- EDIT THIS TO CHANGE THE ROTATION SPEED OF THE PROPS
 config.disableAiming = true -- EDIT THIS TO DISABLE AIMING WHILE PLACING PROPS
-config.placeMessage = "You have placed a prop. Go near it and press E to remove it." -- EDIT THIS TO CHANGE THE MESSAGE THAT APPEARS WHEN YOU PLACE A PROP
+config.placeMessage = "You have placed a prop. Use /"..config.removeCommand..", go near it and press E to remove it." -- EDIT THIS TO CHANGE THE MESSAGE THAT APPEARS WHEN YOU PLACE A PROP
 
 -- EDIT THIS TO CHANGE THE BUTTONS TEXT AND KEYBINDS
 config.buttons = {

--- a/config.lua
+++ b/config.lua
@@ -1,6 +1,6 @@
 config = {}
 
-config.debug = true
+config.debug = false
 config.command = 'polmenu' -- EDIT THIS TO CHANGE THE COMMAND NAME
 config.removeCommand = 'axremove'
 config.removeThreadTimeout = 30 -- in seconds

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -1,6 +1,8 @@
 fx_version 'adamant'
 games { 'gta5' }
 
+lua54 'yes'
+
 shared_script 'config.lua'
 
 server_scripts {"server.lua"}

--- a/server.lua
+++ b/server.lua
@@ -13,6 +13,18 @@ local debug <const> = function(...)
   end
 end
 ------------------------------------------------------
+local props = {}
+
+local findProp <const> = function (position)
+  for index,v in pairs(props) do
+    if #(v.position - position) < 0.1 then
+      table.remove(props, index)
+      return true
+    end
+  end
+
+  return false
+end
 
 RegisterCommand(config.command, function(source)
   if config.hasAccess() then
@@ -22,13 +34,20 @@ RegisterCommand(config.command, function(source)
   end
 end)
 
-local props = {}
 
 RegisterNetEvent('ax:server:addProp',function (propData)
   if type(propData) ~= 'table' then return end
 
   props[#props+1] = propData
   TriggerClientEvent('ax:client:syncProps', -1, props)
+end)
+
+RegisterNetEvent('ax:server:removeProp',function (propCoords)
+  if findProp(propCoords) then
+    TriggerClientEvent('ax:client:syncProps', -1, props)
+  elseif config.debug then
+    print("Unknown prop at coords: "..propCoords)
+  end
 end)
 
 RegisterCommand(config.removeCommand,function (source)

--- a/server.lua
+++ b/server.lua
@@ -1,3 +1,19 @@
+---@diagnostic disable: undefined-global
+------------------------------------------------------
+local debug <const> = function(...)
+  if config.debug then
+      local args = { ... }
+
+      for i = 1, #args do
+          local arg = args[i]
+          args[i] = type(arg) == 'table' and json.encode(arg, { sort_keys = true, indent = true }) or tostring(arg)
+      end
+
+      print('^6[DEBUG] ^7', table.concat(args, '\t'))
+  end
+end
+------------------------------------------------------
+
 RegisterCommand(config.command, function(source)
   if config.hasAccess() then
     TriggerClientEvent("sync-script:polmenu:open", source, config.props)
@@ -5,3 +21,28 @@ RegisterCommand(config.command, function(source)
     TriggerClientEvent("sync-script:polmenu:notify", source, config.noAccessMessage)
   end
 end)
+
+local props = {}
+
+RegisterNetEvent('ax:server:addProp',function (propData)
+  if type(propData) ~= 'table' then return end
+
+  props[#props+1] = propData
+  TriggerClientEvent('ax:client:syncProps', -1, props)
+end)
+
+RegisterCommand(config.removeCommand,function (source)
+  if config.hasAccess() then
+    TriggerClientEvent('ax:client:giveRemoveAccess',source)
+  else 
+    TriggerClientEvent("sync-script:polmenu:notify", source, config.noAccessMessage)
+  end
+end)
+
+AddEventHandler("vRP:playerSpawn",function(user_id,source,first_spawn)
+  if first_spawn then
+    debug(props)
+    TriggerClientEvent('ax:client:syncProps', source, props)
+  end
+end)
+


### PR DESCRIPTION
> The props are synced on all players.
> Props are loaded on spawn so players will see the props when they re-join the server.
> Added Spikes functionality.
> Now the remove function is available only with a command so the marker doesn't appear when you are near the props.
> The Remove Thread has a timeout to stop the Thread if the player won't remove any prop.

Down-side:
> To use the load on spawn, the server needs to use the vRP framework.